### PR TITLE
fix:  fix monitoring validators change

### DIFF
--- a/listener/greenfield_listener.go
+++ b/listener/greenfield_listener.go
@@ -168,9 +168,6 @@ func (l *GreenfieldListener) monitorCrossChainEvents(block *tmtypes.Block, block
 }
 
 func (l *GreenfieldListener) monitorValidators(block *tmtypes.Block, nextHeight uint64) error {
-	if bytes.Equal(block.NextValidatorsHash, block.ValidatorsHash) {
-		return nil
-	}
 	lightClientLatestHeight, err := l.bscExecutor.GetLightClientLatestHeight()
 	if err != nil {
 		return err


### PR DESCRIPTION
Description

fix a issue on monitoring validators change.

Rationale

After unbonding a validator, at the block height of `block.NextValidatorsHash != block.ValidatorsHash`, size of validators does not change, it changes at next height. Causing fail to sync.