### PR TITLE
fix: fix assignment

### DIFF
--- a/assembler/greenfield_assembler.go
+++ b/assembler/greenfield_assembler.go
@@ -124,7 +124,7 @@ func (a *GreenfieldAssembler) process(channelId types.ChannelId, inturnRelayer *
 		a.mutex.Unlock()
 
 		time.Sleep(time.Duration(a.config.RelayConfig.BSCSequenceUpdateLatency) * time.Second)
-		startSequence, err := a.greenfieldExecutor.GetNextDeliverySequenceForChannelWithRetry(channelId)
+		startSequence, err = a.greenfieldExecutor.GetNextDeliverySequenceForChannelWithRetry(channelId)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

fix a assigning issue

### Rationale

shadow variable is not allowed, it will be re-assigned within the the `else` branch.

### Example

NA 

### Changes

Notable changes:
* change from `:=` to `=`