### PR TITLE
fix: outturn relayer should not mark previous tx to delivery

### DIFF
--- a/assembler/bsc_assembler.go
+++ b/assembler/bsc_assembler.go
@@ -107,9 +107,6 @@ func (a *BSCAssembler) process(channelId types.ChannelId) error {
 		if err != nil {
 			return err
 		}
-		if err := a.daoManager.BSCDao.UpdateBatchPackagesStatusToDelivered(startSequence); err != nil {
-			return err
-		}
 	}
 	endSequence, err := a.daoManager.BSCDao.GetLatestOracleSequenceByStatus(db.AllVoted)
 	if err != nil {

--- a/assembler/greenfield_assembler.go
+++ b/assembler/greenfield_assembler.go
@@ -128,9 +128,6 @@ func (a *GreenfieldAssembler) process(channelId types.ChannelId, inturnRelayer *
 		if err != nil {
 			return err
 		}
-		if err := a.daoManager.GreenfieldDao.UpdateBatchTransactionStatusToDelivered(startSequence); err != nil {
-			return err
-		}
 	}
 
 	endSequence, err := a.daoManager.GreenfieldDao.GetLatestSequenceByChannelIdAndStatus(channelId, db.AllVoted)


### PR DESCRIPTION
### Description

do not  mark transaction to delivery for out-turn relayer. As it will skip such tx if re-org happened.

### Rationale

The sequence got from chain to mark tx'status is not always durable.

### Example

NA

### Changes

Notable changes:
* remove marking tx status logic