### PR TITLE
fix: handle edge case of relaying tx

### DIFF
--- a/assembler/bsc_assembler.go
+++ b/assembler/bsc_assembler.go
@@ -2,8 +2,11 @@ package assembler
 
 import (
 	"bytes"
+	"cosmossdk.io/errors"
 	"encoding/hex"
 	"fmt"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
+	oracletypes "github.com/cosmos/cosmos-sdk/x/oracle/types"
 	"time"
 
 	"github.com/bnb-chain/greenfield-relayer/common"
@@ -143,26 +146,28 @@ func (a *BSCAssembler) process(channelId types.ChannelId) error {
 			return nil
 		}
 		if err := a.processPkgs(client, pkgs, uint8(channelId), i, a.relayerNonce, isInturnRelyer); err != nil {
+			if !isInturnRelyer {
+				return err
+			}
 			// There is a slight possibility that multiple batches of transactions are broadcast to the different Nodes with the same block height.
 			// say there are Node1, Node2 and cur Height is H, batch1(tx1, tx2, tx3) is broadcast on Node1, then batch2(tx4, tx5)
 			// broadcast on Node2 will fail due to inconsistency of nonce and channel sequence.
 			// Even the inturn relayer can resume crosschain delivery at next block(Because realyer would retry batch2 at block H+1). But it would
 			// waste plenty of gas. In that case, pasue the relayer 1 block. calibrate inturn relayer nonce and sequence
-			if isInturnRelyer {
+			if errors.IsOf(err, sdkErrors.ErrWrongSequence, oracletypes.ErrInvalidReceiveSequence) {
 				newNonce, nonceErr := a.greenfieldExecutor.GetNonceOnNextBlock()
 				if nonceErr != nil {
 					return nonceErr
 				}
 				a.relayerNonce = newNonce
-				newNextDeliveryOracleSeq, nonceErr := a.bscExecutor.GetNextDeliveryOracleSequenceWithRetry()
-				if nonceErr != nil {
-					return nonceErr
+				newNextDeliveryOracleSeq, seqErr := a.bscExecutor.GetNextDeliveryOracleSequenceWithRetry()
+				if seqErr != nil {
+					return seqErr
 				}
 				a.inturnRelayerSequenceStatus.NextDeliverySeq = newNextDeliveryOracleSeq
 			}
 			return err
 		}
-
 		logging.Logger.Infof("relayed packages with oracle sequence %d ", i)
 		a.relayerNonce++
 	}

--- a/executor/greenfield_executor.go
+++ b/executor/greenfield_executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bnb-chain/greenfield-relayer/logging"
 	"github.com/bnb-chain/greenfield-relayer/types"
 	gnfdsdktypes "github.com/bnb-chain/greenfield/sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type GreenfieldExecutor struct {
@@ -298,6 +299,15 @@ func (e *GreenfieldExecutor) ClaimPackages(client *GnfdCompositeClient, payloadB
 	if err != nil {
 		return "", err
 	}
+
+	if txRes.Codespace == oracletypes.ModuleName && txRes.Code == oracletypes.ErrInvalidReceiveSequence.ABCICode() {
+		return "", oracletypes.ErrInvalidReceiveSequence
+	}
+
+	if txRes.Codespace == sdkErrors.RootCodespace && txRes.Code == sdkErrors.ErrWrongSequence.ABCICode() {
+		return "", sdkErrors.ErrWrongSequence
+	}
+
 	if txRes.Code != 0 {
 		return "", fmt.Errorf("claim error, code=%d, log=%s", txRes.Code, txRes.RawLog)
 	}

--- a/executor/greenfield_executor.go
+++ b/executor/greenfield_executor.go
@@ -271,8 +271,15 @@ func (e *GreenfieldExecutor) GetNonce() (uint64, error) {
 	return acc.GetSequence(), nil
 }
 
-func (e *GreenfieldExecutor) ClaimPackages(client *GnfdCompositeClient, payloadBts []byte, aggregatedSig []byte, voteAddressSet []uint64, claimTs int64, oracleSeq uint64, nonce uint64) (string, error) {
+func (e *GreenfieldExecutor) GetNonceOnNextBlock() (uint64, error) {
+	err := e.GetGnfdClient().WaitForNextBlock(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	return e.GetNonce()
+}
 
+func (e *GreenfieldExecutor) ClaimPackages(client *GnfdCompositeClient, payloadBts []byte, aggregatedSig []byte, voteAddressSet []uint64, claimTs int64, oracleSeq uint64, nonce uint64) (string, error) {
 	txRes, err := client.Claims(context.Background(),
 		e.getSrcChainId(),
 		e.getDestChainId(),


### PR DESCRIPTION
### Description

There is a slight possibility that multiple batches of transactions are broadcast to the different Nodes with the same block height.  Say there are Node1, Node2 and cur Height is H, batch1(tx1, tx2, tx3) is broadcast on Node1, then batch2(tx4, tx5) broadcast on Node2 would fail due to inconsistency of nonce and channel sequence. Even the inturn relayer can resume crosschain delivery at next block(Because realyer would retry batch2 at block H+1). But it would waste plenty of gas. In that case, pasue the relayer 1 block. calibrate nonce and sequence.

### Rationale

Save gas 

### Example

NA

### Changes

Notable changes:
* NA