### PR TITLE
chore: bump go version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 # Set up apk dependencies
 ENV PACKAGES make git libc-dev bash gcc linux-headers eudev-dev curl ca-certificates build-base

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The relayer mainly consists of 3 components: Listener, Vote Processor and Transa
 
 ### Requirement
 
-Go version above 1.19
+Go version above 1.20
 
 ## Deployment 
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/bnb-chain/greenfield v0.2.3
-	github.com/bnb-chain/greenfield-go-sdk v0.2.3-alpha.3.0.20230724054656-5614440e16f1
+	github.com/bnb-chain/greenfield-go-sdk v0.2.3
 	github.com/cometbft/cometbft v0.37.1
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/ethereum/go-ethereum v1.10.26

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bnb-chain/greenfield-relayer
 
-go 1.19
+go 1.20
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go/v4 v4.3.1
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/bnb-chain/greenfield v0.2.3
-	github.com/bnb-chain/greenfield-go-sdk v0.2.3
+	github.com/bnb-chain/greenfield-go-sdk v0.2.3-alpha.3.0.20230724054656-5614440e16f1
 	github.com/cometbft/cometbft v0.37.1
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/ethereum/go-ethereum v1.10.26


### PR DESCRIPTION
### Description

bump go version to 1.20

### Rationale

bump go version to 1.20

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...