### PR TITLE
fix: tx already sent by inturn relayer but fail to udpate DB tx status

### DIFF
--- a/assembler/bsc_assembler.go
+++ b/assembler/bsc_assembler.go
@@ -186,7 +186,7 @@ func (a *BSCAssembler) process(channelId types.ChannelId) error {
 			// broadcast on Node2 will fail due to inconsistency of nonce and channel sequence.
 			// Even the inturn relayer can resume crosschain delivery at next block(Because realyer would retry batch2 at block H+1). But it would
 			// waste plenty of gas. In that case, pasue the relayer 1 block. calibrate inturn relayer nonce and sequence
-			if errors.IsOf(err, sdkErrors.ErrWrongSequence, oracletypes.ErrInvalidReceiveSequence) {
+			if errors.IsOf(err, sdkErrors.ErrWrongSequence, sdkErrors.ErrTxInMempoolCache, oracletypes.ErrInvalidReceiveSequence) {
 				newNonce, nonceErr := a.greenfieldExecutor.GetNonceOnNextBlock()
 				if nonceErr != nil {
 					return nonceErr

--- a/executor/greenfield_executor.go
+++ b/executor/greenfield_executor.go
@@ -327,6 +327,10 @@ func (e *GreenfieldExecutor) ClaimPackages(client *GreenfieldClient, payloadBts 
 		return "", sdkErrors.ErrWrongSequence
 	}
 
+	if txRes.Codespace == sdkErrors.RootCodespace && txRes.Code == sdkErrors.ErrTxInMempoolCache.ABCICode() {
+		return "", sdkErrors.ErrTxInMempoolCache
+	}
+
 	if txRes.Code != 0 {
 		return "", fmt.Errorf("claim error, code=%d, log=%s", txRes.Code, txRes.RawLog)
 	}


### PR DESCRIPTION
### Description

tx already sent by inturn relayer but fail to udpate DB tx status, it will keep retrying

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...